### PR TITLE
Update executequery.md

### DIFF
--- a/pages/operations/executequery.md
+++ b/pages/operations/executequery.md
@@ -39,7 +39,7 @@ You can pass a parameter via the following objects.
 - `Dictionary<string, object>`
 - `Query Objects`
 
-##### Dynamic
+##### Anonymous Types
 
 ```csharp
 using (var connection = new SqlConnection(connectionString).EnsureOpen())


### PR DESCRIPTION
Correction - example uses anonymous types, not a dynamic object.