### PR TITLE
Update executequery.md

### DIFF
--- a/pages/operations/executequery.md
+++ b/pages/operations/executequery.md
@@ -36,7 +36,7 @@ You can pass a parameter via the following objects.
 
 - `Dynamic`
 - `ExpandoObject`
-- `Dictionary<string, object>`
+- `IDictionary<string, object>`
 - `Query Objects`
 
 ##### Anonymous Types

--- a/pages/operations/executequery.md
+++ b/pages/operations/executequery.md
@@ -59,7 +59,7 @@ using (var connection = new SqlConnection(connectionString).EnsureOpen())
 }
 ```
 
-##### Dictionary
+##### IDictionary
 
 ```csharp
 using (var connection = new SqlConnection(connectionString).EnsureOpen())


### PR DESCRIPTION
IDictionary works fine, doesn't need to be a concrete Dictionary. This is good to know from an F# perspective as you can just do e.g.

```fsharp
let data = conn.ExecuteQuery("SELECT * FROM Capacity WHERE Col = @P1", dict [ "P1", box "Value" ])
```

`dict` is a built-in function in F# that takes in an IEnumerable of tuples and creates an IDictionary from it.