### PR TITLE
[Fix] Add the missing left bracket

### DIFF
--- a/pages/operations/executequery.md
+++ b/pages/operations/executequery.md
@@ -200,7 +200,7 @@ using (var connection = new SqlConnection(connectionString))
     {
         Keys = new [] { 10045, 10102, 11004 }
     };
-    var people = connection.ExecuteQuery<Person>("SELECT * FROM dbo].[Person] WHERE Id IN (@Keys);", param);
+    var people = connection.ExecuteQuery<Person>("SELECT * FROM [dbo].[Person] WHERE Id IN (@Keys);", param);
 }
 ```
 


### PR DESCRIPTION
Hello!
Thanks a lot for helping me use RepoDB.

I found that the left bracket was missing in an example of OPERATIONS > ExecuteQuery and added it.
![image](https://user-images.githubusercontent.com/55262136/135798817-0eb6f03d-0ddd-4256-bcc5-77b339f5e87f.png)

I hope this helps you even a little bit. Thank you.